### PR TITLE
Sigquit signal change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /go/src/github.com/kubernetes
 RUN git clone https://github.com/kubernetes/ingress-nginx
 WORKDIR /go/src/github.com/kubernetes/ingress-nginx/cmd/waitshutdown
 COPY main.go .
+RUN go mod download github.com/google/pprof
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o new-wait-shutdown .
 
 FROM busybox:latest  

--- a/main.go
+++ b/main.go
@@ -21,13 +21,14 @@ import (
 	"os/exec"
 	"time"
 
+	"net/http"
+
 	"k8s.io/ingress-nginx/internal/nginx"
 	"k8s.io/klog/v2"
-	"net/http"
 )
 
 func main() {
-	err := exec.Command("bash", "-c", "pkill -SIGTERM -f nginx-ingress-controller").Run()
+	err := exec.Command("bash", "-c", "pkill -SIGQUIT -f nginx-ingress-controller").Run()
 	if err != nil {
 		klog.Errorf("error terminating ingress controller!: %s", err)
 		os.Exit(1)
@@ -64,4 +65,3 @@ func main() {
 		}
 	}
 }
-

--- a/main.go
+++ b/main.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package main
 
 import (


### PR DESCRIPTION
Changing initial command to a sigquit.  Change to using the /metrics for a health check.  Increase for loop interval (30 secs)
and change to use localhost for the health check